### PR TITLE
ignore large deps/ dir and others for lighter published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,5 @@
 /node_modules
+/deps
+/test
+/tools
 /sshpk-agent-*.tgz


### PR DESCRIPTION
Before:
    $ rm -f *.tgz && npm pack && ls -l *.tgz
    sshpk-agent-1.1.1.tgz
    -rw-r--r--  1 trentm  staff   864K Oct 14 09:55 sshpk-agent-1.1.1.tgz

After:
    $ rm -f *.tgz && npm pack && ls -l *.tgz
    sshpk-agent-1.1.1.tgz
    -rw-r--r--  1 trentm  staff   8.6K Oct 14 09:55 sshpk-agent-1.1.1.tgz